### PR TITLE
metainfo.xml: replace developer_name by developer

### DIFF
--- a/org.audiveris.audiveris.metainfo.xml
+++ b/org.audiveris.audiveris.metainfo.xml
@@ -56,7 +56,7 @@
     </screenshot>
   </screenshots>
   <launchable type="desktop-id">org.audiveris.audiveris.desktop</launchable>
-  <developer_name>Hervé Bitteur et al.</developer_name>
+  <developer id="org.audiveris"><name>Hervé Bitteur</name></developer>
   <releases>
     <release version="5.7" date="2025-09-06" urgency="low" type="stable">
       <description>


### PR DESCRIPTION
Fix this warning:

I: org.audiveris.audiveris:59: developer-name-tag-deprecated
   The toplevel `developer_name` element is deprecated. Please use the `name` element in a
   `developer` block instead.

I: org.audiveris.audiveris:~: developer-info-missing
   This component contains no `developer` element with information about its author.

See also:
https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#developer-name